### PR TITLE
Remove link lowercase transformation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export const getPreviewData = async (text: string) => {
   }
 
   try {
-    const link = text.toLowerCase().match(REGEX_LINK)?.[0]
+    const link = text.match(REGEX_LINK)?.[0]
 
     if (!link) return previewData
 


### PR DESCRIPTION
## Description
`getPreviewData` function forces the url to be lowercase. It leads to incorrect handling of the case sensitive URLs. As an example, shorten URLs are case sensitive - http://goo.gl/l6MS is not the same as http://goo.gl/l6ms.